### PR TITLE
add pugixml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -yq  \
 	# libs
 	uuid-dev \
 	libexpat1-dev \
+	libpugixml-dev \
 	libspdlog-dev \
 	# upnp (184)
 	libupnp-dev \


### PR DESCRIPTION
for a short transition time we need libexpat1-dev + libpugixml-dev, afterwards i expect libexpat1-dev will be no longer needed. Like this we can see that pull request gerbera#607 works